### PR TITLE
fix: NullPointerException on start

### DIFF
--- a/src/main/java/software/coley/recaf/launch/util/Config.java
+++ b/src/main/java/software/coley/recaf/launch/util/Config.java
@@ -42,7 +42,7 @@ public class Config {
 	 * @return {@code true} when we've already checked updates recently.
 	 */
 	public static boolean hasCheckedForUpdatesRecently(boolean log) {
-		Instant lastUpdate = instance.getLastUpdateCheck();
+		Instant lastUpdate = getInstance().getLastUpdateCheck();
 		Instant nextCheckTime = lastUpdate.plus(instance.getUpdateCheckRate());
 		Instant now = Instant.now();
 		if (now.isBefore(nextCheckTime)) {


### PR DESCRIPTION
Fix for

```
$ java -jar recaf-launcher-0.1.2.jar auto
java.lang.NullPointerException: Cannot invoke "software.coley.recaf.launch.util.Config.getLastUpdateCheck()" because "software.coley.recaf.launch.util.Config.instance" is null
        at software.coley.recaf.launch.util.Config.hasCheckedForUpdatesRecently(Config.java:45)
        at software.coley.recaf.launch.commands.UpdateRecafFromCI.update(UpdateRecafFromCI.java:62)
        at software.coley.recaf.launch.commands.UpdateRecafFromCI.update(UpdateRecafFromCI.java:49)
        at software.coley.recaf.launch.commands.Auto.call(Auto.java:31)
        at software.coley.recaf.launch.commands.Auto.call(Auto.java:10)
        at picocli.CommandLine.executeUserObject(CommandLine.java:2041)
        at picocli.CommandLine.access$1500(CommandLine.java:148)
        at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2461)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2453)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2415)
```