### PR TITLE
Replace Swing JDK chooser with native dialog

### DIFF
--- a/core/src/main/java/software/coley/recaf/launcher/task/JavaEnvTasks.java
+++ b/core/src/main/java/software/coley/recaf/launcher/task/JavaEnvTasks.java
@@ -60,12 +60,9 @@ public class JavaEnvTasks {
 		if (homeEnv != null) {
 			Path homePath = Paths.get(homeEnv);
 			if (Files.isDirectory(homePath)) {
-				String dirName = homePath.getFileName().toString();
-				int version = JavaVersion.fromVersionString(dirName);
-				if (version >= 8) {
-					Path javaPath = homePath.resolve("bin/java");
-					addJavaInstall(new JavaInstall(javaPath, version));
-				}
+				Path javaPath = homePath.resolve("bin/java");
+				if (Files.exists(javaPath))
+					addJavaInstall(javaPath);
 			}
 		}
 
@@ -80,12 +77,9 @@ public class JavaEnvTasks {
 				try (Stream<Path> subDirStream = Files.list(rootPath)) {
 					subDirStream.filter(subDir -> Files.exists(subDir.resolve("bin/java")))
 							.forEach(subDir -> {
-								String dirName = subDir.getFileName().toString();
-								int version = JavaVersion.fromVersionString(dirName);
-								if (version >= 8) {
-									Path javaPath = subDir.resolve("bin/java");
-									addJavaInstall(new JavaInstall(javaPath, version));
-								}
+								Path javaPath = subDir.resolve("bin/java");
+								if (Files.exists(javaPath))
+									addJavaInstall(javaPath);
 							});
 				} catch (IOException ignored) {
 					// Skip
@@ -108,12 +102,9 @@ public class JavaEnvTasks {
 		if (homeEnv != null) {
 			Path homePath = Paths.get(homeEnv);
 			if (Files.isDirectory(homePath)) {
-				String dirName = homePath.getFileName().toString();
-				int version = JavaVersion.fromVersionString(dirName);
-				if (version >= 8) {
-					Path javaPath = homePath.resolve("bin/java.exe");
-					addJavaInstall(new JavaInstall(javaPath, version));
-				}
+				Path javaPath = homePath.resolve("bin/java.exe");
+				if (Files.exists(javaPath))
+					addJavaInstall(javaPath);
 			}
 		}
 
@@ -145,12 +136,9 @@ public class JavaEnvTasks {
 				try (Stream<Path> subDirStream = Files.list(rootPath)) {
 					subDirStream.filter(subDir -> Files.exists(subDir.resolve("bin/java.exe")))
 							.forEach(subDir -> {
-								String dirName = subDir.getFileName().toString();
-								int version = JavaVersion.fromVersionString(dirName);
-								if (version >= 8) {
-									Path javaPath = subDir.resolve("bin/java.exe");
-									addJavaInstall(new JavaInstall(javaPath, version));
-								}
+								Path javaPath = subDir.resolve("bin/java.exe");
+								if (Files.exists(javaPath))
+									addJavaInstall(javaPath);
 							});
 				} catch (IOException ignored) {
 					// Skip

--- a/core/src/main/java/software/coley/recaf/launcher/util/SymLinks.java
+++ b/core/src/main/java/software/coley/recaf/launcher/util/SymLinks.java
@@ -1,0 +1,36 @@
+package software.coley.recaf.launcher.util;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Symbolic link utils
+ */
+public class SymLinks {
+	private static final int MAX_LINK_DEPTH = 10;
+
+	/**
+	 * @param path
+	 * 		Symbolic link to follow.
+	 *
+	 * @return Target path, or {@code null} if the path could not be resolved.
+	 */
+	@Nullable
+	public static Path resolveSymLink(@Nonnull Path path) {
+		try {
+			int linkDepth = 0;
+			while (Files.isSymbolicLink(path)) {
+				if (linkDepth > MAX_LINK_DEPTH)
+					throw new IOException("Sym-link path too deep");
+				path = Files.readSymbolicLink(path);
+				linkDepth++;
+			}
+			return path;
+		} catch (IOException ex) {
+			return null;
+		}
+	}
+}

--- a/gui/src/main/java/software/coley/recaf/launcher/LauncherGui.java
+++ b/gui/src/main/java/software/coley/recaf/launcher/LauncherGui.java
@@ -17,10 +17,7 @@ import javax.annotation.Nonnull;
 import javax.imageio.ImageIO;
 import javax.swing.*;
 import javax.swing.plaf.FontUIResource;
-import java.awt.Container;
-import java.awt.Dimension;
-import java.awt.Font;
-import java.awt.GraphicsEnvironment;
+import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -51,6 +48,8 @@ public class LauncherGui {
 		thread.setDaemon(false);
 		thread.start();
 	};
+	/** Recaf icon */
+	public static BufferedImage recafImage;
 	/** Recaf icon */
 	public static Icon recafIcon;
 	/** Flag for when the user is launching this for the first time */
@@ -101,9 +100,9 @@ public class LauncherGui {
 		JFrame frame = new JFrame();
 		frame.setTitle("Recaf Launcher");
 		try {
-			BufferedImage iconImage = ImageIO.read(Objects.requireNonNull(LauncherGui.class.getResource("/images/logo.png")));
-			frame.setIconImage(iconImage);
-			recafIcon = new ImageIcon(iconImage);
+			recafImage = ImageIO.read(Objects.requireNonNull(LauncherGui.class.getResource("/images/logo.png")));
+			frame.setIconImage(recafImage);
+			recafIcon = new ImageIcon(recafImage);
 		} catch (IOException ex) {
 			logger.error("Failed to set launcher icon");
 		}


### PR DESCRIPTION
I wanted to choose a JDK located in `~/.jdks` on my Linux machine and noticed that the existing dialog doesn't allow showing hidden files at all, so I replaced it with the AWT version which opens the native file chooser which is way better than the Swing implementation